### PR TITLE
Renaming items to clearly be the context

### DIFF
--- a/src/GreenPipes.Tests/CircuitBreaker_Specs.cs
+++ b/src/GreenPipes.Tests/CircuitBreaker_Specs.cs
@@ -25,7 +25,7 @@ namespace GreenPipes.Tests
         public async Task Should_allow_the_first_call()
         {
             var count = 0;
-            IPipe<A> pipe = Pipe.New<A>(x =>
+            IPipe<TestContext> pipe = Pipe.New<TestContext>(x =>
             {
                 x.UseCircuitBreaker(v => v.ResetInterval(TimeSpan.FromSeconds(60)));
                 x.UseExecute(payload =>
@@ -36,7 +36,7 @@ namespace GreenPipes.Tests
                 });
             });
 
-            var context = new A();
+            var context = new TestContext();
 
             for (var i = 0; i < 100; i++)
                 Assert.That(async () => await pipe.Send(context).ConfigureAwait(false), Throws.TypeOf<IntentionalTestException>());
@@ -45,11 +45,11 @@ namespace GreenPipes.Tests
         }
 
 
-        class A :
+        class TestContext :
             BasePipeContext,
             PipeContext
         {
-            public A()
+            public TestContext()
                 : base(new PayloadCache())
             {
             }

--- a/src/GreenPipes.Tests/ConcurrencyLimit_Specs.cs
+++ b/src/GreenPipes.Tests/ConcurrencyLimit_Specs.cs
@@ -32,10 +32,10 @@ namespace GreenPipes.Tests
             var currentCount = 0;
             var maxCount = 0;
 
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(cfg =>
             {
-                x.UseConcurrencyLimit(32);
-                x.UseExecuteAsync(async payload =>
+                cfg.UseConcurrencyLimit(32);
+                cfg.UseExecuteAsync(async cxt =>
                 {
                     var current = Interlocked.Increment(ref currentCount);
                     while (current > maxCount)
@@ -47,7 +47,7 @@ namespace GreenPipes.Tests
                 });
             });
 
-            var context = new Input("Hello");
+            var context = new InputContext("Hello");
 
             Task[] tasks = Enumerable.Range(0, 500)
                 .Select(index => Task.Run(async () => await pipe.Send(context)))
@@ -66,10 +66,10 @@ namespace GreenPipes.Tests
 
             ICommandRouter dynamicRouter = new CommandRouter();
 
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(cfg =>
             {
-                x.UseConcurrencyLimit(1, dynamicRouter);
-                x.UseExecuteAsync(async payload =>
+                cfg.UseConcurrencyLimit(1, dynamicRouter);
+                cfg.UseExecuteAsync(async cxt =>
                 {
                     var current = Interlocked.Increment(ref currentCount);
                     while (current > maxCount)
@@ -86,7 +86,7 @@ namespace GreenPipes.Tests
                 ConcurrencyLimit = 32
             });
 
-            var context = new Input("Hello");
+            var context = new InputContext("Hello");
 
             Task[] tasks = Enumerable.Range(0, 500)
                 .Select(index => Task.Run(async () => await pipe.Send(context)))
@@ -103,10 +103,10 @@ namespace GreenPipes.Tests
             var currentCount = 0;
             var maxCount = 0;
 
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(cfg =>
             {
-                x.UseConcurrencyLimit(1);
-                x.UseExecuteAsync(async payload =>
+                cfg.UseConcurrencyLimit(1);
+                cfg.UseExecuteAsync(async cxt =>
                 {
                     var current = Interlocked.Increment(ref currentCount);
                     while (current > maxCount)
@@ -118,7 +118,7 @@ namespace GreenPipes.Tests
                 });
             });
 
-            var context = new Input("Hello");
+            var context = new InputContext("Hello");
 
             Task[] tasks = Enumerable.Range(0, 50)
                 .Select(index => Task.Run(async () => await pipe.Send(context)))
@@ -135,7 +135,7 @@ namespace GreenPipes.Tests
         {
             IPipeContextConverter<CommandContext, TOutput> IPipeContextConverterFactory<CommandContext>.GetConverter<TOutput>()
             {
-                var innerType = typeof(TOutput).GetClosingArguments(typeof(Input<>)).Single();
+                var innerType = typeof(TOutput).GetClosingArguments(typeof(InputContext<>)).Single();
 
                 return (IPipeContextConverter<CommandContext, TOutput>)Activator.CreateInstance(typeof(Converter<>).MakeGenericType(innerType));
             }

--- a/src/GreenPipes.Tests/DynamicRouter_Specs.cs
+++ b/src/GreenPipes.Tests/DynamicRouter_Specs.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using GreenPipes.Filters;
+using GreenPipes.Pipes;
+using NUnit.Framework;
+
+namespace GreenPipes.Tests
+{
+    public class DynamicRouter_Specs
+    {
+            [Test]
+            public async Task Dispatching_a_pipe_by_type()
+            {
+                var dr = new DynamicRouter<Cxt>(new CxtFac());
+            }
+        
+    }
+
+    public class CxtFac : IPipeContextConverterFactory<Cxt>
+    {
+        IPipeContextConverter<Cxt, TOutput> IPipeContextConverterFactory<Cxt>.GetConverter<TOutput>()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class Cxt : 
+        BasePipeContext,
+        PipeContext
+    {
+        
+    }
+}

--- a/src/GreenPipes.Tests/Parent_Child_Pipes.cs
+++ b/src/GreenPipes.Tests/Parent_Child_Pipes.cs
@@ -17,13 +17,13 @@ namespace GreenPipes.Tests
             var count1 = 0;
             var count2 = 0;
 
-            var pipe2 = Pipe.New<InitialContext>(x =>
+            var pipe2 = Pipe.New<InitialContext>(cfg =>
             {
-                x.UseExecuteAsync(async payload =>
+                cfg.UseExecuteAsync(async cxt =>
                 {
-                    var pipe1 = Pipe.New<SubContext>(xx =>
+                    var pipe1 = Pipe.New<SubContext>(subCfg =>
                     {
-                        xx.UseExecute(p =>
+                        subCfg.UseExecute(subCxt =>
                         {
                             Interlocked.Increment(ref count1);
                         });
@@ -52,19 +52,19 @@ namespace GreenPipes.Tests
             var count1 = 0;
             var count2 = 0;
 
-            var pipe1 = Pipe.New<InitialContext>(xx =>
+            var pipe1 = Pipe.New<InitialContext>(cfg =>
             {
-                xx.UseExecute(p =>
+                cfg.UseExecute(cxt =>
                 {
                     Interlocked.Increment(ref count1);
                 });
             });
 
-            var pipe2 = Pipe.New<InitialContext>(x =>
+            var pipe2 = Pipe.New<InitialContext>(cfg =>
             {
-                x.UseFork(pipe1);
+                cfg.UseFork(pipe1);
 
-                x.UseExecuteAsync(async payload =>
+                cfg.UseExecuteAsync(async cxt =>
                 {
                     Interlocked.Increment(ref count2);
                 });

--- a/src/GreenPipes.Tests/Profile_Specs.cs
+++ b/src/GreenPipes.Tests/Profile_Specs.cs
@@ -23,13 +23,13 @@ namespace GreenPipes.Tests
         [Test]
         public async Task Should_write_to_the_console()
         {
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(cfg =>
             {
-                x.UseConsoleProfile();
-                x.UseExecuteAsync(context => Task.Delay(10));
+                cfg.UseConsoleProfile();
+                cfg.UseExecuteAsync(cxt => Task.Delay(10));
             });
 
-            await Task.WhenAll(Enumerable.Range(0, 100).Select(x => pipe.Send(new Input("Hello"))));
+            await Task.WhenAll(Enumerable.Range(0, 100).Select(x => pipe.Send(new InputContext("Hello"))));
         }
     }
 }

--- a/src/GreenPipes.Tests/RateLimit_Specs.cs
+++ b/src/GreenPipes.Tests/RateLimit_Specs.cs
@@ -17,7 +17,6 @@ namespace GreenPipes.Tests
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Control;
     using NUnit.Framework;
     using Pipes;
 
@@ -29,16 +28,16 @@ namespace GreenPipes.Tests
         public async Task Should_only_do_n_messages_per_interval()
         {
             int count = 0;
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(x =>
             {
                 x.UseRateLimit(10, TimeSpan.FromSeconds(1));
-                x.UseExecute(payload =>
+                x.UseExecute(cxt =>
                 {
                     Interlocked.Increment(ref count);
                 });
             });
 
-            var context = new Input("Hello");
+            var context = new InputContext("Hello");
 
             var timer = Stopwatch.StartNew();
 
@@ -58,10 +57,10 @@ namespace GreenPipes.Tests
         {
             var router = new CommandRouter();
             int count = 0;
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(cfg =>
             {
-                x.UseRateLimit(10, TimeSpan.FromSeconds(1), router);
-                x.UseExecute(payload =>
+                cfg.UseRateLimit(10, TimeSpan.FromSeconds(1), router);
+                cfg.UseExecute(cxt =>
                 {
                     Interlocked.Increment(ref count);
                 });
@@ -69,7 +68,7 @@ namespace GreenPipes.Tests
 
             await router.SetRateLimit(100);
 
-            var context = new Input("Hello");
+            var context = new InputContext("Hello");
 
             var timer = Stopwatch.StartNew();
 
@@ -89,10 +88,10 @@ namespace GreenPipes.Tests
         {
             var router = new CommandRouter();
             int count = 0;
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(cfg =>
             {
-                x.UseRateLimit(100, TimeSpan.FromSeconds(1), router);
-                x.UseExecute(payload =>
+                cfg.UseRateLimit(100, TimeSpan.FromSeconds(1), router);
+                cfg.UseExecute(cxt =>
                 {
                     Interlocked.Increment(ref count);
                 });
@@ -100,7 +99,7 @@ namespace GreenPipes.Tests
 
             await router.SetRateLimit(10);
 
-            var context = new Input("Hello");
+            var context = new InputContext("Hello");
 
             var timer = Stopwatch.StartNew();
 
@@ -119,10 +118,10 @@ namespace GreenPipes.Tests
         public async Task Should_count_success_and_failure_as_same()
         {
             int count = 0;
-            IPipe<Input> pipe = Pipe.New<Input>(x =>
+            IPipe<InputContext> pipe = Pipe.New<InputContext>(cfg =>
             {
-                x.UseRateLimit(10, TimeSpan.FromSeconds(1));
-                x.UseExecute(payload =>
+                cfg.UseRateLimit(10, TimeSpan.FromSeconds(1));
+                cfg.UseExecute(cxt =>
                 {
                     var index = Interlocked.Increment(ref count);
                     if (index % 2 == 0)
@@ -130,7 +129,7 @@ namespace GreenPipes.Tests
                 });
             });
 
-            var context = new Input("Hello");
+            var context = new InputContext("Hello");
 
             var timer = Stopwatch.StartNew();
 

--- a/src/GreenPipes.Tests/Retry_Specs.cs
+++ b/src/GreenPipes.Tests/Retry_Specs.cs
@@ -20,11 +20,11 @@ namespace GreenPipes.Tests
     [TestFixture]
     public class Using_the_retry_filter
     {
-        class A :
+        class TestContext :
             BasePipeContext,
             PipeContext
         {
-            public A()
+            public TestContext()
                 : base(new PayloadCache())
             {                
             }
@@ -35,7 +35,7 @@ namespace GreenPipes.Tests
         public void Should_retry_the_specified_times_and_fail()
         {
             int count = 0;
-            IPipe<A> pipe = Pipe.New<A>(x =>
+            IPipe<TestContext> pipe = Pipe.New<TestContext>(x =>
             {
                 x.UseRetry(r => r.Interval(4, TimeSpan.FromMilliseconds(2)));
                 x.UseExecute(payload =>
@@ -45,7 +45,7 @@ namespace GreenPipes.Tests
                 });
             });
 
-            var context = new A();
+            var context = new TestContext();
 
             Assert.That(async () => await pipe.Send(context), Throws.TypeOf<IntentionalTestException>());
 
@@ -56,7 +56,7 @@ namespace GreenPipes.Tests
         public void Should_support_overloading_downstream()
         {
             int count = 0;
-            IPipe<A> pipe = Pipe.New<A>(x =>
+            IPipe<TestContext> pipe = Pipe.New<TestContext>(x =>
             {
                 x.UseRetry(r => r.Interval(4, TimeSpan.FromMilliseconds(2)));
                 x.UseRetry(r => r.None());
@@ -67,7 +67,7 @@ namespace GreenPipes.Tests
                 });
             });
 
-            var context = new A();
+            var context = new TestContext();
 
             Assert.That(async () => await pipe.Send(context), Throws.TypeOf<IntentionalTestException>());
 
@@ -78,7 +78,7 @@ namespace GreenPipes.Tests
         public void Should_support_overloading_downstream_either_way()
         {
             int count = 0;
-            IPipe<A> pipe = Pipe.New<A>(x =>
+            IPipe<TestContext> pipe = Pipe.New<TestContext>(x =>
             {
                 x.UseRetry(r => r.None());
                 x.UseRetry(r => r.Interval(4, TimeSpan.FromMilliseconds(2)));
@@ -89,7 +89,7 @@ namespace GreenPipes.Tests
                 });
             });
 
-            var context = new A();
+            var context = new TestContext();
 
             Assert.That(async () => await pipe.Send(context), Throws.TypeOf<IntentionalTestException>());
 

--- a/src/GreenPipes/Configuration/DelegateConfigurationExtensions.cs
+++ b/src/GreenPipes/Configuration/DelegateConfigurationExtensions.cs
@@ -22,16 +22,16 @@ namespace GreenPipes
         /// <summary>
         /// Executes a synchronous method on the pipe
         /// </summary>
-        /// <typeparam name="T">The context type</typeparam>
+        /// <typeparam name="TContext">The context type</typeparam>
         /// <param name="configurator">The pipe configurator</param>
         /// <param name="callback">The callback to invoke</param>
-        public static void UseExecute<T>(this IPipeConfigurator<T> configurator, Action<T> callback)
-            where T : class, PipeContext
+        public static void UseExecute<TContext>(this IPipeConfigurator<TContext> configurator, Action<TContext> callback)
+            where TContext : class, PipeContext
         {
             if (configurator == null)
                 throw new ArgumentNullException(nameof(configurator));
 
-            var pipeBuilderConfigurator = new DelegatePipeSpecification<T>(callback);
+            var pipeBuilderConfigurator = new DelegatePipeSpecification<TContext>(callback);
 
             configurator.AddPipeSpecification(pipeBuilderConfigurator);
         }
@@ -39,16 +39,16 @@ namespace GreenPipes
         /// <summary>
         /// Executes an asynchronous method on the pipe
         /// </summary>
-        /// <typeparam name="T">The context type</typeparam>
+        /// <typeparam name="TContext">The context type</typeparam>
         /// <param name="configurator">The pipe configurator</param>
         /// <param name="callback">The callback to invoke</param>
-        public static void UseExecuteAsync<T>(this IPipeConfigurator<T> configurator, Func<T, Task> callback)
-            where T : class, PipeContext
+        public static void UseExecuteAsync<TContext>(this IPipeConfigurator<TContext> configurator, Func<TContext, Task> callback)
+            where TContext : class, PipeContext
         {
             if (configurator == null)
                 throw new ArgumentNullException(nameof(configurator));
 
-            var pipeBuilderConfigurator = new AsyncDelegatePipeSpecification<T>(callback);
+            var pipeBuilderConfigurator = new AsyncDelegatePipeSpecification<TContext>(callback);
 
             configurator.AddPipeSpecification(pipeBuilderConfigurator);
         }

--- a/src/GreenPipes/IFilterObserver.cs
+++ b/src/GreenPipes/IFilterObserver.cs
@@ -46,15 +46,15 @@ namespace GreenPipes
     }
 
 
-    public interface IFilterObserver<in T>
-        where T : class, PipeContext
+    public interface IFilterObserver<in TContext>
+        where TContext : class, PipeContext
     {
         /// <summary>
         /// Called before a message is dispatched to any consumers
         /// </summary>
         /// <param name="context">The consume context</param>
         /// <returns></returns>
-        Task PreSend(T context);
+        Task PreSend(TContext context);
 
         /// <summary>
         /// Called after the message has been dispatched to all consumers - note that in the case of an exception
@@ -62,7 +62,7 @@ namespace GreenPipes
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        Task PostSend(T context);
+        Task PostSend(TContext context);
 
         /// <summary>
         /// Called after the message has been dispatched to all consumers when one or more exceptions have occurred
@@ -70,6 +70,6 @@ namespace GreenPipes
         /// <param name="context"></param>
         /// <param name="exception"></param>
         /// <returns></returns>
-        Task SendFault(T context, Exception exception);
+        Task SendFault(TContext context, Exception exception);
     }
 }


### PR DESCRIPTION
Per a conversation with @phatboyg renaming test variables from payload to `cxt` or `context` to drive home the clarity of what a payload is vs a context.
